### PR TITLE
MW-134: Added missing error message

### DIFF
--- a/src/report/messages_en.json
+++ b/src/report/messages_en.json
@@ -7,6 +7,7 @@
     "report.generateReport": "Generate Report",
     "report.geographicZoneInfo": "If no option is selected, report will include all geographic zones.",
     "report.html": "HTML",
+    "report.noReports": "No Reports",
     "report.pdf": "PDF",
     "report.report": "Report",
     "report.reports": "Reports",

--- a/src/report/report-list.html
+++ b/src/report/report-list.html
@@ -1,7 +1,7 @@
 <h2>{{'report.viewReports' | message}}</h2>
 <div class="openlmis-table-container">
     <table>
-        <caption class="error" ng-if="!vm.reports.length">{{'message.no.reports' | message}}</caption>
+        <caption class="error" ng-if="!vm.reports.length">{{'report.noReports' | message}}</caption>
         <thead>
             <tr>
                 <th>{{'report.report' | message}}</th>


### PR DESCRIPTION
 UI seemed to be missing an English translation for "message.no.reports". I've changed message name to follow our standards and added it to the JSON file with messages.