### PR TITLE
OLMIS-6478: Made Superset Server URL Configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+5.2.1 / WIP
+==================
+
+Improvements:
+* [OLMIS-6478](https://openlmis.atlassian.net/browse/OLMIS-6478): Made Superset Server URL Configurable
+
 5.2.0 / 2019-05-27
 ==================
 

--- a/src/report/superset-report.controller.js
+++ b/src/report/superset-report.controller.js
@@ -70,7 +70,7 @@
         function onInit() {
             vm.reportCode = reportCode;
             vm.reportUrl = reportUrl;
-            vm.authUrl = 'https://superset.uat.openlmis.org/login/openlmis';
+            vm.authUrl = '${SUPERSET_URL}/login/openlmis';
         }
 
     }

--- a/src/report/superset-report.routes.js
+++ b/src/report/superset-report.routes.js
@@ -24,6 +24,10 @@
     config.$inject = ['$stateProvider', 'SUPERSET_REPORTS'];
 
     function config($stateProvider, SUPERSET_REPORTS) {
+        if (angular.equals(SUPERSET_REPORTS, {})) {
+            // nothing to do here
+            return;
+        }
 
         $stateProvider.state('openlmis.reports.list.superset', {
             abstract: true,
@@ -36,13 +40,9 @@
             }
         });
 
-        addReporingPage($stateProvider, SUPERSET_REPORTS.REPORTING_RATE_AND_TIMELINESS);
-        addReporingPage($stateProvider, SUPERSET_REPORTS.STOCK_STATUS);
-        addReporingPage($stateProvider, SUPERSET_REPORTS.STOCKOUTS);
-        addReporingPage($stateProvider, SUPERSET_REPORTS.CONSUMPTION);
-        addReporingPage($stateProvider, SUPERSET_REPORTS.ORDERS);
-        addReporingPage($stateProvider, SUPERSET_REPORTS.ADJUSTMENTS);
-        addReporingPage($stateProvider, SUPERSET_REPORTS.ADMINISTRATIVE);
+        Object.values(SUPERSET_REPORTS).forEach(function(report) {
+            addReporingPage($stateProvider, report);
+        });
     }
 
     function addReporingPage($stateProvider, report) {

--- a/src/report/superset-reports.constant.js
+++ b/src/report/superset-reports.constant.js
@@ -29,27 +29,33 @@
         .constant('SUPERSET_REPORTS', getReports());
 
     function getReports() {
+        var supersetUrl = '${SUPERSET_URL}';
+
+        if (supersetUrl.substr(0, 2) === '${') {
+            return {};
+        }
+
         return {
             REPORTING_RATE_AND_TIMELINESS: createReport('reportingRateAndTimeliness',
-                'https://superset.uat.openlmis.org/login/openlmis?redirect_url=/superset/dashboard/1/',
+                supersetUrl + '/superset/dashboard/1/',
                 'REPORTING_RATE_AND_TIMELINESS_REPORT_VIEW'),
             STOCK_STATUS: createReport('stockStatus',
-                'https://superset.uat.openlmis.org/login/openlmis?redirect_url=/superset/dashboard/6/',
+                supersetUrl + '/superset/dashboard/6/',
                 'STOCK_STATUS_REPORT_VIEW'),
             STOCKOUTS: createReport('stockouts',
-                'https://superset.uat.openlmis.org/login/openlmis?redirect_url=/superset/dashboard/2/',
+                supersetUrl + '/superset/dashboard/2/',
                 'STOCKOUTS_REPORT_VIEW'),
             CONSUMPTION: createReport('consumption',
-                'https://superset.uat.openlmis.org/login/openlmis?redirect_url=/superset/dashboard/3/',
+                supersetUrl + '/superset/dashboard/3/',
                 'CONSUMPTION_REPORT_VIEW'),
             ORDERS: createReport('orders',
-                'https://superset.uat.openlmis.org/login/openlmis?redirect_url=/superset/dashboard/4/',
+                supersetUrl + '/superset/dashboard/4/',
                 'ORDERS_REPORT_VIEW'),
             ADJUSTMENTS: createReport('adjustments',
-                'https://superset.uat.openlmis.org/login/openlmis?redirect_url=/superset/dashboard/5/',
+                supersetUrl + '/superset/dashboard/5/',
                 'ADJUSTMENTS_REPORT_VIEW'),
             ADMINISTRATIVE: createReport('administrative',
-                'https://superset.uat.openlmis.org/login/openlmis?redirect_url=/superset/dashboard/7/',
+                supersetUrl + '/superset/dashboard/7/',
                 'ADMINISTRATIVE_REPORT_VIEW')
         };
     }


### PR DESCRIPTION
A stock version of OpenLMIS expects to find the reporting stack on the Core's UAT server and offers no means for specifying an alternative. The Angola and Malawi teams therefore added support for an .env file property called SUPERSET_URL which allows for this configuration. Having it would potentially be useful for core.