### PR TITLE
MW-1449 - Superset Embedded SDK integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 Upcoming Version (WIP)
 ==================
+New functionality:
+* [MW-1449](https://openlmis.atlassian.net/browse/MW-1449): Replaced the Superset OAuth iframe with the Superset Embedded SDK for Superset reports that have an Embedded UUID configured. The legacy OAuth iframe path is preserved as a fallback when no Embedded UUID is set.
 
 5.2.15 / 2025-11-27
 ==================

--- a/src/report/_superset-report.scss
+++ b/src/report/_superset-report.scss
@@ -1,3 +1,15 @@
 iframe {
     flex: 1 0 auto;
 }
+
+.superset-embed-container {
+    width: 100%;
+    height: calc(100vh - 200px);
+    min-height: 600px;
+}
+
+.superset-embed-container iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+}

--- a/src/report/dashboard-report.controller.js
+++ b/src/report/dashboard-report.controller.js
@@ -22,17 +22,19 @@
      * @name report.controller:DashboardReportController
      *
      * @description
-     * Controller for dashboard report view.
+     * Controller for dashboard report view. For Superset reports, uses the
+     * Superset Embedded SDK to render the dashboard via a guest token.
      */
     angular
         .module('report')
         .controller('DashboardReportController', DashboardReportController);
 
-    DashboardReportController.inject = ['reportName', 'isSupersetReport', 'reportUrl', 'loadingModalService',
-        'messageService', 'supersetLocaleService', 'SUPERSET_URL'];
+    DashboardReportController.$inject = ['reportName', 'isSupersetReport', 'reportUrl',
+        'embeddedUuid', '$http', '$q', '$element', '$scope', 'SUPERSET_URL', 'openlmisUrlFactory'];
 
-    function DashboardReportController(reportName, isSupersetReport, reportUrl, loadingModalService, messageService,
-                                       supersetLocaleService, SUPERSET_URL) {
+    function DashboardReportController(reportName, isSupersetReport, reportUrl,
+                                       embeddedUuid, $http, $q, $element, $scope, SUPERSET_URL,
+                                       openlmisUrlFactory) {
         var vm = this;
         vm.$onInit = onInit;
 
@@ -54,20 +56,20 @@
          * @type {string}
          *
          * @description
-         * The report URL.
+         * The report URL (used for non-Superset reports).
          */
         vm.reportUrl = undefined;
 
         /**
          * @ngdoc property
          * @propertyOf report.controller:DashboardReportController
-         * @name authUrl
-         * @type {string}
+         * @name isSupersetReport
+         * @type {boolean}
          *
          * @description
-         * The superset authorization URL.
+         * Whether this is a Superset embedded report.
          */
-        vm.authUrl = undefined;
+        vm.isSupersetReport = false;
 
         /**
          * @ngdoc property
@@ -76,31 +78,94 @@
          * @type {boolean}
          *
          * @description
-         * Indicates if the controller is ready for displaying the Superset iframe.
+         * Indicates if the Superset embedded dashboard has been initialized.
          */
         vm.isReady = false;
+
+        /**
+         * @ngdoc property
+         * @propertyOf report.controller:DashboardReportController
+         * @name error
+         * @type {string}
+         *
+         * @description
+         * Error message to display if embedding fails.
+         */
+        vm.error = undefined;
 
         function onInit() {
             vm.reportName = reportName;
             vm.reportUrl = reportUrl;
             vm.isSupersetReport = isSupersetReport;
-            vm.authUrl = SUPERSET_URL + '/login/openlmis';
 
-            if (vm.isSupersetReport) {
-                adjustSupersetLanguage();
+            if (vm.isSupersetReport && embeddedUuid) {
+                initSupersetEmbed();
+            } else if (vm.isSupersetReport) {
+                vm.error = 'This dashboard has no embedded UUID configured.';
             }
         }
 
-        function adjustSupersetLanguage() {
-            loadingModalService.open();
-
-            var locale = messageService.getCurrentLocale();
-            supersetLocaleService.changeLocale(locale)
-                .then(function() {
+        function initSupersetEmbed() {
+            loadSupersetSdk().then(function(sdk) {
+                const container = $element[0].querySelector('#superset-embed-container');
+                if (!container) {
+                    vm.error = 'Embed container not found.';
+                    $scope.$applyAsync();
+                    return;
+                }
+                sdk.embedDashboard({
+                    id: embeddedUuid,
+                    supersetDomain: SUPERSET_URL,
+                    mountPoint: container,
+                    fetchGuestToken: fetchGuestToken,
+                    dashboardUiConfig: {
+                        hideTitle: true,
+                        hideChartControls: false,
+                        hideTab: false,
+                        filters: {
+                            visible: true,
+                            expanded: false
+                        }
+                    }
+                }).then(function() {
                     vm.isReady = true;
+                    $scope.$applyAsync();
                 })
-                .finally(function() {
-                    loadingModalService.close();
+                    .catch(function(err) {
+                        vm.error = 'Failed to embed dashboard: ' + err.message;
+                        $scope.$applyAsync();
+                    });
+            })
+                .catch(function(err) {
+                    vm.error = 'Failed to load Superset SDK: ' + err.message;
+                    $scope.$applyAsync();
+                });
+        }
+
+        function loadSupersetSdk() {
+            if (window.supersetEmbeddedSdk) {
+                return $q.resolve(window.supersetEmbeddedSdk);
+            }
+            return $http.get(SUPERSET_URL + '/static/superset-embedded-sdk.js', {
+                transformResponse: function(data) {
+                    return data;
+                }
+            }).then(function(response) {
+                new Function(response.data)();
+                if (window.supersetEmbeddedSdk) {
+                    return window.supersetEmbeddedSdk;
+                }
+                throw new Error('Superset Embedded SDK failed to initialize');
+            });
+        }
+
+        function fetchGuestToken() {
+            const url = openlmisUrlFactory(
+                '/api/reports/superset/guest-token?embeddedUuid=' + embeddedUuid
+            );
+            return $http.get(url)
+                .then(function(response) {
+                    return response.data.token;
                 });
         }
     }

--- a/src/report/dashboard-report.controller.js
+++ b/src/report/dashboard-report.controller.js
@@ -22,19 +22,23 @@
      * @name report.controller:DashboardReportController
      *
      * @description
-     * Controller for dashboard report view. For Superset reports, uses the
-     * Superset Embedded SDK to render the dashboard via a guest token.
+     * Controller for dashboard report view. For Superset reports with an embedded UUID,
+     * uses the Superset Embedded SDK to render the dashboard via a guest token.
+     * For Superset reports without an embedded UUID, falls back to the legacy
+     * OAuth iframe approach.
      */
     angular
         .module('report')
         .controller('DashboardReportController', DashboardReportController);
 
     DashboardReportController.$inject = ['reportName', 'isSupersetReport', 'reportUrl',
-        'embeddedUuid', '$http', '$q', '$element', '$scope', 'SUPERSET_URL', 'openlmisUrlFactory'];
+        'embeddedUuid', '$http', '$q', '$element', '$scope', 'SUPERSET_URL', 'openlmisUrlFactory',
+        'loadingModalService', 'messageService', 'supersetLocaleService'];
 
     function DashboardReportController(reportName, isSupersetReport, reportUrl,
                                        embeddedUuid, $http, $q, $element, $scope, SUPERSET_URL,
-                                       openlmisUrlFactory) {
+                                       openlmisUrlFactory, loadingModalService, messageService,
+                                       supersetLocaleService) {
         var vm = this;
         vm.$onInit = onInit;
 
@@ -56,7 +60,7 @@
          * @type {string}
          *
          * @description
-         * The report URL (used for non-Superset reports).
+         * The report URL (used for non-Superset reports and legacy OAuth iframe).
          */
         vm.reportUrl = undefined;
 
@@ -67,9 +71,20 @@
          * @type {boolean}
          *
          * @description
-         * Whether this is a Superset embedded report.
+         * Whether this is a Superset report.
          */
         vm.isSupersetReport = false;
+
+        /**
+         * @ngdoc property
+         * @propertyOf report.controller:DashboardReportController
+         * @name authUrl
+         * @type {string}
+         *
+         * @description
+         * The Superset OAuth authorization URL (legacy iframe path only).
+         */
+        vm.authUrl = undefined;
 
         /**
          * @ngdoc property
@@ -78,7 +93,7 @@
          * @type {boolean}
          *
          * @description
-         * Indicates if the Superset embedded dashboard has been initialized.
+         * Indicates if the dashboard has been initialized and is ready to display.
          */
         vm.isReady = false;
 
@@ -101,8 +116,22 @@
             if (vm.isSupersetReport && embeddedUuid) {
                 initSupersetEmbed();
             } else if (vm.isSupersetReport) {
-                vm.error = 'This dashboard has no embedded UUID configured.';
+                vm.authUrl = SUPERSET_URL + '/login/openlmis';
+                adjustSupersetLanguage();
             }
+        }
+
+        function adjustSupersetLanguage() {
+            loadingModalService.open();
+
+            var locale = messageService.getCurrentLocale();
+            supersetLocaleService.changeLocale(locale)
+                .then(function() {
+                    vm.isReady = true;
+                })
+                .finally(function() {
+                    loadingModalService.close();
+                });
         }
 
         function initSupersetEmbed() {

--- a/src/report/dashboard-report.controller.js
+++ b/src/report/dashboard-report.controller.js
@@ -138,7 +138,7 @@
             loadSupersetSdk().then(function(sdk) {
                 const container = $element[0].querySelector('#superset-embed-container');
                 if (!container) {
-                    vm.error = 'Embed container not found.';
+                    vm.error = messageService.get('report.superset.embed.containerNotFound');
                     $scope.$applyAsync();
                     return;
                 }
@@ -161,12 +161,16 @@
                     $scope.$applyAsync();
                 })
                     .catch(function(err) {
-                        vm.error = 'Failed to embed dashboard: ' + err.message;
+                        vm.error = messageService.get('report.superset.embed.failed', {
+                            error: err.message
+                        });
                         $scope.$applyAsync();
                     });
             })
                 .catch(function(err) {
-                    vm.error = 'Failed to load Superset SDK: ' + err.message;
+                    vm.error = messageService.get('report.superset.sdk.failed', {
+                        error: err.message
+                    });
                     $scope.$applyAsync();
                 });
         }

--- a/src/report/dashboard-report.controller.spec.js
+++ b/src/report/dashboard-report.controller.spec.js
@@ -223,7 +223,7 @@ describe('DashboardReportController', function() {
             $httpBackend.flush();
             that.$rootScope.$digest();
 
-            expect(vm.error).toContain('Failed to load Superset SDK');
+            expect(vm.error).toContain('report.superset.sdk.failed');
         });
 
         it('should not make HTTP request when SDK is cached', function() {

--- a/src/report/dashboard-report.controller.spec.js
+++ b/src/report/dashboard-report.controller.spec.js
@@ -19,8 +19,10 @@ describe('DashboardReportController', function() {
 
     beforeEach(function() {
         that.SUPERSET_URL = 'http://localhost/superset';
-        that.reportUrl = that.SUPERSET_URL + '/theReport';
+        that.reportName = 'Test Report';
+        that.reportUrl = null;
         that.isSupersetReport = true;
+        that.embeddedUuid = 'test-embedded-uuid-1234';
 
         module('report', function($provide) {
             $provide.constant('SUPERSET_URL', that.SUPERSET_URL);
@@ -30,16 +32,25 @@ describe('DashboardReportController', function() {
             that.$controller = $injector.get('$controller');
             that.$q = $injector.get('$q');
             that.$rootScope = $injector.get('$rootScope');
-
-            that.supersetLocaleService = $injector.get('supersetLocaleService');
+            that.$scope = that.$rootScope.$new();
+            that.$http = $injector.get('$http');
+            that.openlmisUrlFactory = $injector.get('openlmisUrlFactory');
         });
 
-        spyOn(that.supersetLocaleService, 'changeLocale').andReturn(that.$q.resolve());
+        // Mock $element with a querySelector that returns null (no DOM in unit tests)
+        that.$element = [{
+            querySelector: function() {
+                return null;
+            }
+        }];
 
         that.vm = that.$controller('DashboardReportController', {
             reportName: that.reportName,
             reportUrl: that.reportUrl,
-            isSupersetReport: that.isSupersetReport
+            isSupersetReport: that.isSupersetReport,
+            embeddedUuid: that.embeddedUuid,
+            $element: that.$element,
+            $scope: that.$scope
         });
     });
 
@@ -47,10 +58,6 @@ describe('DashboardReportController', function() {
 
         beforeEach(function() {
             that.vm.$onInit();
-        });
-
-        it('should expose dashboard iFrame src', function() {
-            expect(that.vm.reportUrl).toEqual(that.reportUrl);
         });
 
         it('should expose isSupersetReport flag', function() {
@@ -61,19 +68,156 @@ describe('DashboardReportController', function() {
             expect(that.vm.reportName).toEqual(that.reportName);
         });
 
-        it('should expose authUrl', function() {
-            expect(that.vm.authUrl).not.toBeUndefined();
+        it('should expose reportUrl as null for Superset reports', function() {
+            expect(that.vm.reportUrl).toBeNull();
         });
 
-        it('should expose isReady', function() {
-            expect(that.vm.isReady).toEqual(false);
+        it('should not show error when embeddedUuid is provided', function() {
+            expect(that.vm.error).toBeUndefined();
+        });
+    });
+
+    describe('onInit without embeddedUuid', function() {
+
+        beforeEach(function() {
+            that.vm = that.$controller('DashboardReportController', {
+                reportName: that.reportName,
+                reportUrl: that.reportUrl,
+                isSupersetReport: true,
+                embeddedUuid: null,
+                $element: that.$element,
+                $scope: that.$scope
+            });
+            that.vm.$onInit();
         });
 
-        it('should adjust language in Superset and change isReady flag', function() {
-            that.$rootScope.$apply();
+        it('should show error when embeddedUuid is missing', function() {
+            expect(that.vm.error).toEqual('This dashboard has no embedded UUID configured.');
+        });
+    });
 
-            expect(that.supersetLocaleService.changeLocale).toHaveBeenCalled();
-            expect(that.vm.isReady).toBe(true);
+    describe('onInit for non-Superset report', function() {
+
+        beforeEach(function() {
+            that.vm = that.$controller('DashboardReportController', {
+                reportName: 'Jasper Report',
+                reportUrl: 'http://example.com/report',
+                isSupersetReport: false,
+                embeddedUuid: null,
+                $element: that.$element,
+                $scope: that.$scope
+            });
+            that.vm.$onInit();
+        });
+
+        it('should expose reportUrl for non-Superset reports', function() {
+            expect(that.vm.reportUrl).toEqual('http://example.com/report');
+        });
+
+        it('should not set isSupersetReport', function() {
+            expect(that.vm.isSupersetReport).toEqual(false);
+        });
+
+        it('should not show error', function() {
+            expect(that.vm.error).toBeUndefined();
+        });
+    });
+
+    describe('SDK loading', function() {
+
+        var $httpBackend, sdkUrl, savedSdk;
+
+        beforeEach(function() {
+            inject(function($injector) {
+                $httpBackend = $injector.get('$httpBackend');
+            });
+
+            sdkUrl = that.SUPERSET_URL + '/static/superset-embedded-sdk.js';
+
+            savedSdk = window.supersetEmbeddedSdk;
+            window.supersetEmbeddedSdk = undefined;
+
+            that.$element = [{
+                querySelector: function() {
+                    return document.createElement('div');
+                }
+            }];
+        });
+
+        afterEach(function() {
+            window.supersetEmbeddedSdk = savedSdk;
+            $httpBackend.verifyNoOutstandingExpectation();
+            $httpBackend.verifyNoOutstandingRequest();
+        });
+
+        it('should load SDK via $http and set it on window', function() {
+            var scriptBody =
+                'window.supersetEmbeddedSdk = {' +
+                '  embedDashboard: function() {' +
+                '    return Promise.resolve();' +
+                '  }' +
+                '};';
+            $httpBackend.expectGET(sdkUrl).respond(200, scriptBody);
+
+            var vm = that.$controller('DashboardReportController', {
+                reportName: that.reportName,
+                reportUrl: that.reportUrl,
+                isSupersetReport: true,
+                embeddedUuid: 'test-uuid',
+                $element: that.$element,
+                $scope: that.$scope
+            });
+
+            vm.$onInit();
+            $httpBackend.flush();
+            that.$rootScope.$digest();
+
+            expect(window.supersetEmbeddedSdk).toBeDefined();
+            expect(window.supersetEmbeddedSdk.embedDashboard)
+                .toBeDefined();
+        });
+
+        it('should set error when SDK load fails', function() {
+            $httpBackend.expectGET(sdkUrl).respond(500, 'Server Error');
+
+            var vm = that.$controller('DashboardReportController', {
+                reportName: that.reportName,
+                reportUrl: that.reportUrl,
+                isSupersetReport: true,
+                embeddedUuid: 'test-uuid',
+                $element: that.$element,
+                $scope: that.$scope
+            });
+
+            vm.$onInit();
+            $httpBackend.flush();
+            that.$rootScope.$digest();
+
+            expect(vm.error).toContain('Failed to load Superset SDK');
+        });
+
+        it('should not make HTTP request when SDK is cached', function() {
+            window.supersetEmbeddedSdk = {
+                embedDashboard: function() {
+                    return that.$q.resolve({});
+                }
+            };
+
+            var vm = that.$controller('DashboardReportController', {
+                reportName: that.reportName,
+                reportUrl: that.reportUrl,
+                isSupersetReport: true,
+                embeddedUuid: 'test-uuid',
+                $element: that.$element,
+                $scope: that.$scope
+            });
+
+            vm.$onInit();
+            that.$rootScope.$digest();
+
+            // No $httpBackend requests expected — verifyNoOutstanding
+            // in afterEach confirms no HTTP was made
+            expect(vm.error).toBeUndefined();
         });
     });
 });

--- a/src/report/dashboard-report.controller.spec.js
+++ b/src/report/dashboard-report.controller.spec.js
@@ -15,7 +15,7 @@
 
 describe('DashboardReportController', function() {
 
-    var that = this;
+    const that = this;
 
     beforeEach(function() {
         that.SUPERSET_URL = 'http://localhost/superset';
@@ -125,7 +125,7 @@ describe('DashboardReportController', function() {
 
     describe('SDK loading', function() {
 
-        var $httpBackend, sdkUrl, savedSdk;
+        let $httpBackend, sdkUrl, savedSdk;
 
         beforeEach(function() {
             inject(function($injector) {
@@ -151,7 +151,7 @@ describe('DashboardReportController', function() {
         });
 
         it('should load SDK via $http and set it on window', function() {
-            var scriptBody =
+            const scriptBody =
                 'window.supersetEmbeddedSdk = {' +
                 '  embedDashboard: function() {' +
                 '    return Promise.resolve();' +
@@ -159,7 +159,7 @@ describe('DashboardReportController', function() {
                 '};';
             $httpBackend.expectGET(sdkUrl).respond(200, scriptBody);
 
-            var vm = that.$controller('DashboardReportController', {
+            const vm = that.$controller('DashboardReportController', {
                 reportName: that.reportName,
                 reportUrl: that.reportUrl,
                 isSupersetReport: true,
@@ -180,7 +180,7 @@ describe('DashboardReportController', function() {
         it('should set error when SDK load fails', function() {
             $httpBackend.expectGET(sdkUrl).respond(500, 'Server Error');
 
-            var vm = that.$controller('DashboardReportController', {
+            const vm = that.$controller('DashboardReportController', {
                 reportName: that.reportName,
                 reportUrl: that.reportUrl,
                 isSupersetReport: true,
@@ -203,7 +203,7 @@ describe('DashboardReportController', function() {
                 }
             };
 
-            var vm = that.$controller('DashboardReportController', {
+            const vm = that.$controller('DashboardReportController', {
                 reportName: that.reportName,
                 reportUrl: that.reportUrl,
                 isSupersetReport: true,

--- a/src/report/dashboard-report.controller.spec.js
+++ b/src/report/dashboard-report.controller.spec.js
@@ -35,7 +35,11 @@ describe('DashboardReportController', function() {
             that.$scope = that.$rootScope.$new();
             that.$http = $injector.get('$http');
             that.openlmisUrlFactory = $injector.get('openlmisUrlFactory');
+
+            that.supersetLocaleService = $injector.get('supersetLocaleService');
         });
+
+        spyOn(that.supersetLocaleService, 'changeLocale').andReturn(that.$q.resolve());
 
         // Mock $element with a querySelector that returns null (no DOM in unit tests)
         that.$element = [{
@@ -54,7 +58,7 @@ describe('DashboardReportController', function() {
         });
     });
 
-    describe('onInit', function() {
+    describe('onInit with embeddedUuid', function() {
 
         beforeEach(function() {
             that.vm.$onInit();
@@ -68,21 +72,29 @@ describe('DashboardReportController', function() {
             expect(that.vm.reportName).toEqual(that.reportName);
         });
 
-        it('should expose reportUrl as null for Superset reports', function() {
+        it('should expose reportUrl as null for embedded Superset reports', function() {
             expect(that.vm.reportUrl).toBeNull();
         });
 
         it('should not show error when embeddedUuid is provided', function() {
             expect(that.vm.error).toBeUndefined();
         });
+
+        it('should not set authUrl for embedded path', function() {
+            expect(that.vm.authUrl).toBeUndefined();
+        });
+
+        it('should not call supersetLocaleService', function() {
+            expect(that.supersetLocaleService.changeLocale).not.toHaveBeenCalled();
+        });
     });
 
-    describe('onInit without embeddedUuid', function() {
+    describe('onInit without embeddedUuid (OAuth fallback)', function() {
 
         beforeEach(function() {
             that.vm = that.$controller('DashboardReportController', {
                 reportName: that.reportName,
-                reportUrl: that.reportUrl,
+                reportUrl: that.SUPERSET_URL + '/superset/dashboard/1/?standalone=true',
                 isSupersetReport: true,
                 embeddedUuid: null,
                 $element: that.$element,
@@ -91,8 +103,22 @@ describe('DashboardReportController', function() {
             that.vm.$onInit();
         });
 
-        it('should show error when embeddedUuid is missing', function() {
-            expect(that.vm.error).toEqual('This dashboard has no embedded UUID configured.');
+        it('should set authUrl for OAuth login', function() {
+            expect(that.vm.authUrl).toEqual(that.SUPERSET_URL + '/login/openlmis');
+        });
+
+        it('should call supersetLocaleService to adjust language', function() {
+            expect(that.supersetLocaleService.changeLocale).toHaveBeenCalled();
+        });
+
+        it('should set isReady after locale adjustment', function() {
+            that.$rootScope.$apply();
+
+            expect(that.vm.isReady).toBe(true);
+        });
+
+        it('should not show error', function() {
+            expect(that.vm.error).toBeUndefined();
         });
     });
 
@@ -120,6 +146,10 @@ describe('DashboardReportController', function() {
 
         it('should not show error', function() {
             expect(that.vm.error).toBeUndefined();
+        });
+
+        it('should not set authUrl', function() {
+            expect(that.vm.authUrl).toBeUndefined();
         });
     });
 

--- a/src/report/dashboard-report.html
+++ b/src/report/dashboard-report.html
@@ -1,7 +1,4 @@
 <h2>{{vm.reportName}}</h2>
-<p ng-if='vm.isSupersetReport'>
-    {{ 'report.superset.auth.pageRequiresAuthorization' | message }}
-    <a href="{{vm.authUrl}}">{{ 'report.superset.auth.clickingHere' | message }}</a>
-</p>
-<iframe ng-if='vm.isSupersetReport && vm.isReady' seamless frameBorder="0" scrolling="auto" ng-src="{{vm.reportUrl}}"></iframe>
-<iframe ng-if='!vm.isSupersetReport' seamless frameBorder="0" scrolling="auto" allowFullScreen="true" ng-src="{{vm.reportUrl}}"></iframe>
+<p ng-if="vm.error" class="alert alert-danger">{{vm.error}}</p>
+<div ng-if="vm.isSupersetReport" id="superset-embed-container" class="superset-embed-container"></div>
+<iframe ng-if="!vm.isSupersetReport" seamless allowFullScreen="true" title="{{vm.reportName}}" ng-src="{{vm.reportUrl}}"></iframe>

--- a/src/report/dashboard-report.html
+++ b/src/report/dashboard-report.html
@@ -1,4 +1,12 @@
 <h2>{{vm.reportName}}</h2>
 <p ng-if="vm.error" class="alert alert-danger">{{vm.error}}</p>
-<div ng-if="vm.isSupersetReport" id="superset-embed-container" class="superset-embed-container"></div>
+<p ng-if="vm.isSupersetReport && vm.authUrl">
+    {{ 'report.superset.auth.pageRequiresAuthorization' | message }}
+    <a href="{{vm.authUrl}}">{{ 'report.superset.auth.clickingHere' | message }}</a>
+</p>
+<iframe ng-if="vm.isSupersetReport && vm.authUrl && vm.isReady" seamless frameBorder="0" scrolling="auto" ng-src="{{vm.reportUrl}}"></iframe>
+<p ng-if="vm.isSupersetReport && !vm.authUrl && !vm.isReady && !vm.error" class="loading">
+    {{ 'report.superset.loading' | message }}
+</p>
+<div ng-if="vm.isSupersetReport && !vm.authUrl" ng-show="vm.isReady" id="superset-embed-container" class="superset-embed-container"></div>
 <iframe ng-if="!vm.isSupersetReport" seamless allowFullScreen="true" title="{{vm.reportName}}" ng-src="{{vm.reportUrl}}"></iframe>

--- a/src/report/dashboard-reports.factory.js
+++ b/src/report/dashboard-reports.factory.js
@@ -81,11 +81,13 @@
         }
 
         function createResolve(report) {
-            const resolve = {
+            var resolve = {
                 reportUrl: function($sce) {
-                    // Superset reports use embedded SDK, not iframe URL
                     if (report.type === REPORT_TYPES.SUPERSET) {
-                        return null;
+                        if (report.embeddedUuid) {
+                            return null;
+                        }
+                        return $sce.trustAsResourceUrl(report.url + '?standalone=true');
                     }
                     return $sce.trustAsResourceUrl(report.url);
                 },
@@ -99,7 +101,31 @@
                     return report.type === REPORT_TYPES.SUPERSET ? report.embeddedUuid : null;
                 }
             };
+            if (report.type === REPORT_TYPES.SUPERSET && !report.embeddedUuid) {
+                resolve['authorizationInSuperset'] = authorizeInSuperset;
+            }
             return resolve;
+        }
+
+        function authorizeInSuperset(loadingModalService, openlmisModalService, $q, $state,
+                                     MODAL_CANCELLED) {
+            loadingModalService.close();
+            var dialog = openlmisModalService.createDialog({
+                backdrop: 'static',
+                keyboard: false,
+                controller: 'SupersetOAuthLoginController',
+                controllerAs: 'vm',
+                templateUrl: 'openlmis-superset/superset-oauth-login.html',
+                show: true
+            });
+            return dialog.promise
+                .catch(function(reason) {
+                    if (reason === MODAL_CANCELLED) {
+                        $state.go('openlmis.reports.list');
+                        return $q.resolve();
+                    }
+                    return $q.reject();
+                });
         }
     }
 

--- a/src/report/dashboard-reports.factory.js
+++ b/src/report/dashboard-reports.factory.js
@@ -81,10 +81,11 @@
         }
 
         function createResolve(report) {
-            var resolve = {
+            const resolve = {
                 reportUrl: function($sce) {
+                    // Superset reports use embedded SDK, not iframe URL
                     if (report.type === REPORT_TYPES.SUPERSET) {
-                        return $sce.trustAsResourceUrl(report.url + '?standalone=true');
+                        return null;
                     }
                     return $sce.trustAsResourceUrl(report.url);
                 },
@@ -93,32 +94,12 @@
                 },
                 isSupersetReport: function() {
                     return report.type === REPORT_TYPES.SUPERSET;
+                },
+                embeddedUuid: function() {
+                    return report.type === REPORT_TYPES.SUPERSET ? report.embeddedUuid : null;
                 }
             };
-            if (report.type === REPORT_TYPES.SUPERSET) {
-                resolve['authorizationInSuperset'] = authorizeInSuperset;
-            }
             return resolve;
-        }
-
-        function authorizeInSuperset(loadingModalService, openlmisModalService, $q, $state, MODAL_CANCELLED) {
-            loadingModalService.close();
-            var dialog = openlmisModalService.createDialog({
-                backdrop: 'static',
-                keyboard: false,
-                controller: 'SupersetOAuthLoginController',
-                controllerAs: 'vm',
-                templateUrl: 'openlmis-superset/superset-oauth-login.html',
-                show: true
-            });
-            return dialog.promise
-                .catch(function(reason) {
-                    if (reason === MODAL_CANCELLED) {
-                        $state.go('openlmis.reports.list');
-                        return $q.resolve();
-                    }
-                    return $q.reject();
-                });
         }
     }
 

--- a/src/report/messages_en.json
+++ b/src/report/messages_en.json
@@ -18,5 +18,8 @@
     "report.boolean.false": "No",
     "report.superset.auth.pageRequiresAuthorization": "This page requires authorization in the reporting stack. If nothing shows up, you still can authorize manually by",
     "report.superset.auth.clickingHere": "clicking here",
-    "report.superset.loading": "Loading dashboard..."
+    "report.superset.loading": "Loading dashboard...",
+    "report.superset.embed.containerNotFound": "Embed container not found.",
+    "report.superset.embed.failed": "Failed to embed dashboard: ${error}",
+    "report.superset.sdk.failed": "Failed to load Superset SDK: ${error}"
 }

--- a/src/report/messages_en.json
+++ b/src/report/messages_en.json
@@ -15,7 +15,5 @@
     "report.xls": "XLS",
     "report.xlsx": "XLSX",
     "report.boolean.true": "Yes",
-    "report.boolean.false": "No",
-    "report.superset.auth.pageRequiresAuthorization": "This page requires authorization in the reporting stack. If nothing shows up, you still can authorize manually by",
-    "report.superset.auth.clickingHere": "clicking here"
+    "report.boolean.false": "No"
 }

--- a/src/report/messages_en.json
+++ b/src/report/messages_en.json
@@ -15,5 +15,8 @@
     "report.xls": "XLS",
     "report.xlsx": "XLSX",
     "report.boolean.true": "Yes",
-    "report.boolean.false": "No"
+    "report.boolean.false": "No",
+    "report.superset.auth.pageRequiresAuthorization": "This page requires authorization in the reporting stack. If nothing shows up, you still can authorize manually by",
+    "report.superset.auth.clickingHere": "clicking here",
+    "report.superset.loading": "Loading dashboard..."
 }

--- a/src/report/report.module.js
+++ b/src/report/report.module.js
@@ -33,6 +33,7 @@
         'openlmis-permissions',
         'openlmis-main-state',
         'ui.router',
+        'openlmis-superset',
         'report-category',
         'report-dashboard'
     ]);

--- a/src/report/report.module.js
+++ b/src/report/report.module.js
@@ -33,7 +33,6 @@
         'openlmis-permissions',
         'openlmis-main-state',
         'ui.router',
-        'openlmis-superset',
         'report-category',
         'report-dashboard'
     ]);


### PR DESCRIPTION
Replaces the legacy superset-patchup OAuth login modal with the official Superset Embedded SDK, compatible with Superset 6.0 and the new SolDevelo reporting stack. WIP until the reporting stack integration is tested and merged.

## Summary
- Replace OAuth login modal with Superset Embedded SDK for rendering dashboards
- SDK loaded at runtime from Superset's `/static/` endpoint
- Remove `openlmis-superset` module dependency
